### PR TITLE
Add check if category exists before attempting to push new item

### DIFF
--- a/src/items/items.service.ts
+++ b/src/items/items.service.ts
@@ -39,7 +39,15 @@ export const create = async (newItem: BaseItem): Promise<Item> => {
   const item: Item = { ...newItem, id };
 
   itemsDb[id] = item;
-  menusDb[item.category].items.push(item.id);
+  
+  if (!menusDb[item.category]) {
+    menusDb[item.category] = {
+      id: item.category,
+      items: [item.id]
+    }
+  } else {
+    menusDb[item.category].items.push(item.id);
+  }
 
   await updateItemsDb(itemsDb);
   await updateMenusDb(menusDb);


### PR DESCRIPTION
This was returning 500s on the Angular app if the user tries to add a new menu item with a category that didn't exist previously in the database.

@dan-auth0 